### PR TITLE
Use a custom phase instead of the main_opaque_3d phase.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-in
 trace = ["bevy/trace_chrome"]
 
 [dependencies.bevy]
-version = "0.12.1"
+version = "0.13.0"
 default-features = false
 features = ["bevy_asset", "bevy_core_pipeline", "bevy_render", "x11"]
 
 [dev-dependencies]
 rand = "0.8"
-smooth-bevy-cameras = "0.10"
+smooth-bevy-cameras = "0.11"
 
 [[example]]
 name = "wave"

--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -92,7 +92,5 @@ fn toggle_fps_controller(
 ) {
     if mouse_button_input.just_pressed(MouseButton::Left) {
         controller.single_mut().enabled = true;
-    } else if mouse_button_input.just_pressed(MouseButton::Right) {
-        controller.single_mut().enabled = false;
     }
 }

--- a/examples/bloom.rs
+++ b/examples/bloom.rs
@@ -3,7 +3,6 @@ use bevy::{
         bloom::{BloomCompositeMode, BloomPrefilterSettings, BloomSettings},
         tonemapping::Tonemapping,
     },
-    input::mouse,
     prelude::*,
 };
 use bevy_aabb_instancing::{Cuboid, CuboidMaterialId, Cuboids, VertexPullingRenderPlugin};
@@ -88,10 +87,12 @@ fn setup(mut commands: Commands) {
 }
 
 fn toggle_fps_controller(
-    mouse_button_input: Res<Input<MouseButton>>,
+    mouse_button_input: Res<ButtonInput<MouseButton>>,
     mut controller: Query<&mut FpsCameraController>,
 ) {
     if mouse_button_input.just_pressed(MouseButton::Left) {
         controller.single_mut().enabled = true;
+    } else if mouse_button_input.just_pressed(MouseButton::Right) {
+        controller.single_mut().enabled = false;
     }
 }

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -79,7 +79,7 @@ fn update_scalar_hue_options(time: Res<Time>, mut material_map: ResMut<CuboidMat
 }
 
 fn toggle_fps_controller(
-    mouse_button_input: Res<Input<MouseButton>>,
+    mouse_button_input: Res<ButtonInput<MouseButton>>,
     mut controller: Query<&mut FpsCameraController>,
 ) {
     if mouse_button_input.just_pressed(MouseButton::Left) {

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -84,7 +84,5 @@ fn toggle_fps_controller(
 ) {
     if mouse_button_input.just_pressed(MouseButton::Left) {
         controller.single_mut().enabled = true;
-    } else if mouse_button_input.just_pressed(MouseButton::Right) {
-        controller.single_mut().enabled = false;
     }
 }

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -84,5 +84,7 @@ fn toggle_fps_controller(
 ) {
     if mouse_button_input.just_pressed(MouseButton::Left) {
         controller.single_mut().enabled = true;
+    } else if mouse_button_input.just_pressed(MouseButton::Right) {
+        controller.single_mut().enabled = false;
     }
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -156,7 +156,7 @@ impl CuboidMaterialMap {
         uniforms.clear();
         let mut indices = Vec::new();
         for material in self.materials.iter() {
-            indices.push(CuboidMaterialUniformIndex(uniforms.push(material.clone())));
+            indices.push(CuboidMaterialUniformIndex(uniforms.push(material)));
         }
         indices
     }

--- a/src/vertex_pulling.rs
+++ b/src/vertex_pulling.rs
@@ -5,6 +5,8 @@ mod cuboid_cache;
 mod draw;
 mod extract;
 mod index_buffer;
+mod node;
+mod phase;
 mod pipeline;
 mod prepare;
 mod queue;

--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -1,6 +1,9 @@
 use super::{cuboid_cache::CuboidBufferCache, index_buffer::CuboidsIndexBuffer};
 use bevy::{
-    ecs::{query::ROQueryItem, system::{lifetimeless::*, SystemParamItem}},
+    ecs::{
+        query::ROQueryItem,
+        system::{lifetimeless::*, SystemParamItem},
+    },
     prelude::*,
     render::{
         render_asset::RenderAssets,

--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -30,13 +30,14 @@ pub(crate) struct SetCuboidsViewBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetCuboidsViewBindGroup<I> {
     type Param = SRes<ViewMeta>;
-    type ItemWorldQuery = ();
-    type ViewWorldQuery = Read<ViewUniformOffset>;
+    type ItemQuery = ();
+    type ViewQuery = Read<ViewUniformOffset>;
+
     #[inline]
     fn render<'w>(
         _item: &P,
-        view_uniform_offset: &'_ ViewUniformOffset,
-        _entity: (),
+        view_uniform_offset: Self::ViewQuery,
+        _entity: Option<Self::ItemQuery>,
         view_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -63,20 +64,20 @@ pub(crate) struct SetAuxBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetAuxBindGroup<I> {
     type Param = (SRes<CuboidBufferCache>, SRes<AuxiliaryMeta>);
-    type ItemWorldQuery = Entity;
-    type ViewWorldQuery = ();
+    type ItemQuery = Entity;
+    type ViewQuery = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: (),
-        entity: Entity,
+        _view: Self::ViewQuery,
+        entity: Option<Self::ItemQuery>,
         (buffer_cache, aux_meta): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let buffer_cache = buffer_cache.into_inner();
         let aux_meta = aux_meta.into_inner();
-        let entry = buffer_cache.entries.get(&entity).unwrap();
+        let entry = buffer_cache.entries.get(&entity.unwrap()).unwrap();
         pass.set_bind_group(
             I,
             aux_meta.bind_group.as_ref().unwrap(),
@@ -95,19 +96,23 @@ pub(crate) struct SetGpuTransformBufferBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetGpuTransformBufferBindGroup<I> {
     type Param = (SRes<CuboidBufferCache>, SRes<TransformsMeta>);
-    type ItemWorldQuery = Entity;
-    type ViewWorldQuery = ();
+    type ItemQuery = Entity;
+    type ViewQuery = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: (),
-        entity: Entity,
+        _view: Self::ViewQuery,
+        entity: Option<Self::ItemQuery>,
         (buffer_cache, transforms_meta): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let transforms_meta = transforms_meta.into_inner();
-        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
+        let entry = buffer_cache
+            .into_inner()
+            .entries
+            .get(&entity.unwrap())
+            .unwrap();
         pass.set_bind_group(
             I,
             transforms_meta
@@ -124,18 +129,22 @@ pub(crate) struct SetGpuCuboidBuffersBindGroup<const I: usize>;
 
 impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetGpuCuboidBuffersBindGroup<I> {
     type Param = SRes<CuboidBufferCache>;
-    type ItemWorldQuery = Entity;
-    type ViewWorldQuery = ();
+    type ItemQuery = Entity;
+    type ViewQuery = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: (),
-        entity: Entity,
+        _view: Self::ViewQuery,
+        entity: Option<Self::ItemQuery>,
         buffer_cache: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
+        let entry = buffer_cache
+            .into_inner()
+            .entries
+            .get(&entity.unwrap())
+            .unwrap();
         pass.set_bind_group(I, entry.instance_buffer_bind_group.as_ref().unwrap(), &[]);
         RenderCommandResult::Success
     }
@@ -148,19 +157,23 @@ impl<P: PhaseItem> RenderCommand<P> for DrawVertexPulledCuboids {
         SRes<CuboidBufferCache>,
         SRes<RenderAssets<CuboidsIndexBuffer>>,
     );
-    type ItemWorldQuery = Entity;
-    type ViewWorldQuery = ();
+    type ItemQuery = Entity;
+    type ViewQuery = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        _view: (),
-        entity: Entity,
+        _view: Self::ViewQuery,
+        entity: Option<Self::ItemQuery>,
         (buffer_cache, index_buffers): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         use super::index_buffer::{CUBE_INDICES, CUBE_INDICES_HANDLE};
-        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
+        let entry = buffer_cache
+            .into_inner()
+            .entries
+            .get(&entity.unwrap())
+            .unwrap();
         let num_cuboids = entry.instance_buffer.get().len().try_into().unwrap();
         let index_buffer = index_buffers
             .into_inner()

--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -1,6 +1,6 @@
 use super::{cuboid_cache::CuboidBufferCache, index_buffer::CuboidsIndexBuffer};
 use bevy::{
-    ecs::system::{lifetimeless::*, SystemParamItem},
+    ecs::{query::ROQueryItem, system::{lifetimeless::*, SystemParamItem}},
     prelude::*,
     render::{
         render_asset::RenderAssets,
@@ -36,7 +36,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetCuboidsViewBindGroup<
     #[inline]
     fn render<'w>(
         _item: &P,
-        view_uniform_offset: Self::ViewQuery,
+        view_uniform_offset: ROQueryItem<'w, Self::ViewQuery>,
         _entity: Option<Self::ItemQuery>,
         view_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,

--- a/src/vertex_pulling/extract.rs
+++ b/src/vertex_pulling/extract.rs
@@ -1,10 +1,12 @@
 use super::buffers::*;
 use super::cuboid_cache::CuboidBufferCache;
+use super::phase::AabbOpaque3d;
 use crate::clipping_planes::*;
 use crate::cuboids::*;
 use crate::CuboidMaterialId;
 use crate::CuboidMaterialMap;
 
+use bevy::render::render_phase::RenderPhase;
 use bevy::{prelude::*, render::Extract};
 
 #[allow(clippy::type_complexity)]
@@ -95,4 +97,17 @@ pub(crate) fn extract_clipping_planes(
         );
     }
     clipping_plane_uniform.set(gpu_planes);
+}
+
+pub(crate) fn extract_camera_phases(
+    mut commands: Commands,
+    camemras_3d: Extract<Query<(Entity, &Camera), With<Camera3d>>>,
+) {
+    for (entity, camera) in camemras_3d.iter() {
+        if camera.is_active {
+            commands
+                .get_or_spawn(entity)
+                .insert(RenderPhase::<AabbOpaque3d>::default());
+        }
+    }
 }

--- a/src/vertex_pulling/index_buffer.rs
+++ b/src/vertex_pulling/index_buffer.rs
@@ -1,17 +1,17 @@
 use bevy::{
     asset::{Asset, Handle},
     core::cast_slice,
-    ecs::system::lifetimeless::SRes,
-    reflect::{TypePath, TypeUuid},
+    ecs::system::{lifetimeless::SRes, SystemParamItem},
+    reflect::TypePath,
     render::{
-        render_asset::RenderAsset,
+        render_asset::{PrepareAssetError, RenderAsset, RenderAssetUsages},
         render_resource::{Buffer, BufferInitDescriptor, BufferUsages},
         renderer::RenderDevice,
     },
 };
 
-#[derive(Asset, Default, TypeUuid, TypePath)]
-#[uuid = "8f6d78a6-fffe-4e54-81db-08b0739a947a"]
+#[derive(Asset, Clone, Default, TypePath)]
+// #[uuid = "8f6d78a6-fffe-4e54-81db-08b0739a947a"]
 pub struct CuboidsIndexBuffer;
 
 pub(crate) const CUBE_INDICES_HANDLE: Handle<CuboidsIndexBuffer> =
@@ -34,23 +34,19 @@ pub(crate) const CUBE_INDICES: [u32; NUM_CUBE_INDICES_USIZE] = [
 ];
 
 impl RenderAsset for CuboidsIndexBuffer {
-    type ExtractedAsset = Self;
-
     type PreparedAsset = Buffer;
 
     type Param = SRes<RenderDevice>;
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        Self
+    fn asset_usage(&self) -> RenderAssetUsages {
+        // TODO
+        RenderAssetUsages::all()
     }
 
     fn prepare_asset(
-        _extracted_asset: Self::ExtractedAsset,
-        render_device: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
-    ) -> Result<
-        Self::PreparedAsset,
-        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
-    > {
+        self,
+        render_device: &mut SystemParamItem<Self::Param>,
+    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self>> {
         let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
             usage: BufferUsages::INDEX,
             label: Some("Cuboid Index Buffer"),

--- a/src/vertex_pulling/node.rs
+++ b/src/vertex_pulling/node.rs
@@ -39,7 +39,7 @@ impl ViewNode for AabbOpaquePass3dNode {
         let view_entity = graph.view_entity();
         render_context.add_command_buffer_generation_task(move |render_device| {
             #[cfg(feature = "trace")]
-            let _main_opaque_pass_3d_span = info_span!("main_opaque_pass_3d").entered();
+            let _aabb_opaque_pass_3d_span = info_span!("aabb_opaque_pass_3d").entered();
 
             // Command encoder setup
             let mut command_encoder =

--- a/src/vertex_pulling/node.rs
+++ b/src/vertex_pulling/node.rs
@@ -1,0 +1,76 @@
+use bevy::{
+    ecs::{query::QueryItem, world::World},
+    render::{
+        camera::ExtractedCamera,
+        render_graph::{NodeRunError, RenderGraphContext, RenderLabel, ViewNode},
+        render_phase::{RenderPhase, TrackedRenderPass},
+        render_resource::{CommandEncoderDescriptor, RenderPassDescriptor, StoreOp},
+        renderer::RenderContext,
+        view::{ViewDepthTexture, ViewTarget},
+    },
+};
+
+use super::phase::AabbOpaque3d;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
+pub struct AabbOpaquePass3dLabel;
+
+#[derive(Default)]
+pub struct AabbOpaquePass3dNode;
+
+impl ViewNode for AabbOpaquePass3dNode {
+    type ViewQuery = (
+        &'static ExtractedCamera,
+        &'static RenderPhase<AabbOpaque3d>,
+        &'static ViewTarget,
+        &'static ViewDepthTexture,
+    );
+
+    fn run<'w>(
+        &self,
+        graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext<'w>,
+        (camera, aabb_opaque_phase, target, depth): QueryItem<'w, Self::ViewQuery>,
+        world: &'w World,
+    ) -> Result<(), NodeRunError> {
+        let color_attachments = [Some(target.get_color_attachment())];
+        let depth_stencil_attachment = Some(depth.get_attachment(StoreOp::Store));
+
+        let view_entity = graph.view_entity();
+        render_context.add_command_buffer_generation_task(move |render_device| {
+            #[cfg(feature = "trace")]
+            let _main_opaque_pass_3d_span = info_span!("main_opaque_pass_3d").entered();
+
+            // Command encoder setup
+            let mut command_encoder =
+                render_device.create_command_encoder(&CommandEncoderDescriptor {
+                    label: Some("aabb_opaque_pass_3d_command_encoder"),
+                });
+
+            // Render pass setup
+            let render_pass = command_encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("aabb_opaque_pass_3d"),
+                color_attachments: &color_attachments,
+                depth_stencil_attachment,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            let mut render_pass = TrackedRenderPass::new(&render_device, render_pass);
+            if let Some(viewport) = camera.viewport.as_ref() {
+                render_pass.set_camera_viewport(viewport);
+            }
+
+            // Opaque draws
+            if !aabb_opaque_phase.items.is_empty() {
+                #[cfg(feature = "trace")]
+                let _opaque_main_pass_3d_span = info_span!("aabb_main_pass_3d").entered();
+                aabb_opaque_phase.render(&mut render_pass, world, view_entity);
+            }
+
+            drop(render_pass);
+            command_encoder.finish()
+        });
+
+        Ok(())
+    }
+}

--- a/src/vertex_pulling/phase.rs
+++ b/src/vertex_pulling/phase.rs
@@ -1,0 +1,66 @@
+use std::{cmp::Reverse, ops::Range};
+
+use bevy::{ecs::entity::Entity, render::{render_phase::{CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem}, render_resource::CachedRenderPipelineId}, utils::{nonmax::NonMaxU32, FloatOrd}};
+
+pub struct AabbOpaque3d {
+    pub distance: f32,
+    pub pipeline: CachedRenderPipelineId,
+    pub entity: Entity,
+    pub draw_function: DrawFunctionId,
+    pub batch_range: Range<u32>,
+    pub dynamic_offset: Option<NonMaxU32>,
+}
+
+impl PhaseItem for AabbOpaque3d {
+    // NOTE: Values increase towards the camera. Front-to-back ordering for opaque means we need a descending sort.
+    type SortKey = Reverse<FloatOrd>;
+
+    #[inline]
+    fn entity(&self) -> Entity {
+        self.entity
+    }
+
+    #[inline]
+    fn sort_key(&self) -> Self::SortKey {
+        Reverse(FloatOrd(self.distance))
+    }
+
+    #[inline]
+    fn draw_function(&self) -> DrawFunctionId {
+        self.draw_function
+    }
+
+    #[inline]
+    fn sort(items: &mut [Self]) {
+        // Key negated to match reversed SortKey ordering
+        items.sort_by_key(|item| item.sort_key());
+        // radsort::sort_by_key(items, |item| -item.distance);
+    }
+
+    #[inline]
+    fn batch_range(&self) -> &Range<u32> {
+        &self.batch_range
+    }
+
+    #[inline]
+    fn batch_range_mut(&mut self) -> &mut Range<u32> {
+        &mut self.batch_range
+    }
+
+    #[inline]
+    fn dynamic_offset(&self) -> Option<NonMaxU32> {
+        self.dynamic_offset
+    }
+
+    #[inline]
+    fn dynamic_offset_mut(&mut self) -> &mut Option<NonMaxU32> {
+        &mut self.dynamic_offset
+    }
+}
+
+impl CachedRenderPipelinePhaseItem for AabbOpaque3d {
+    #[inline]
+    fn cached_pipeline(&self) -> CachedRenderPipelineId {
+        self.pipeline
+    }
+}

--- a/src/vertex_pulling/phase.rs
+++ b/src/vertex_pulling/phase.rs
@@ -1,6 +1,13 @@
 use std::{cmp::Reverse, ops::Range};
 
-use bevy::{ecs::entity::Entity, render::{render_phase::{CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem}, render_resource::CachedRenderPipelineId}, utils::{nonmax::NonMaxU32, FloatOrd}};
+use bevy::{
+    ecs::entity::Entity,
+    render::{
+        render_phase::{CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem},
+        render_resource::CachedRenderPipelineId,
+    },
+    utils::{nonmax::NonMaxU32, FloatOrd},
+};
 
 pub struct AabbOpaque3d {
     pub distance: f32,

--- a/src/vertex_pulling/pipeline.rs
+++ b/src/vertex_pulling/pipeline.rs
@@ -8,12 +8,11 @@ use bevy::{
     render::{
         mesh::PrimitiveTopology,
         render_resource::{
-            BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType,
-            BlendState, BufferBindingType, BufferSize, CachedRenderPipelineId, ColorTargetState,
-            ColorWrites, CompareFunction, DepthBiasState, DepthStencilState, FragmentState,
-            FrontFace, MultisampleState, PipelineCache, PolygonMode, PrimitiveState,
-            RenderPipelineDescriptor, ShaderStages, ShaderType, StencilFaceState, StencilState,
-            TextureFormat, VertexState,
+            BindGroupLayout, BindGroupLayoutEntry, BindingType, BlendState, BufferBindingType,
+            BufferSize, CachedRenderPipelineId, ColorTargetState, ColorWrites, CompareFunction,
+            DepthBiasState, DepthStencilState, FragmentState, FrontFace, MultisampleState,
+            PipelineCache, PolygonMode, PrimitiveState, RenderPipelineDescriptor, ShaderStages,
+            ShaderType, StencilFaceState, StencilState, TextureFormat, VertexState,
         },
         renderer::RenderDevice,
         view::ViewUniform,
@@ -38,9 +37,9 @@ impl FromWorld for CuboidsPipelines {
     fn from_world(world: &mut World) -> Self {
         let render_device = world.resource::<RenderDevice>();
 
-        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            label: Some("cuboids_view_layout"),
-            entries: &[
+        let view_layout = render_device.create_bind_group_layout(
+            Some("cuboids_view_layout"),
+            &[
                 // View
                 BindGroupLayoutEntry {
                     binding: 0,
@@ -53,11 +52,11 @@ impl FromWorld for CuboidsPipelines {
                     count: None,
                 },
             ],
-        });
+        );
 
-        let aux_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            label: Some("aux_layout"),
-            entries: &[
+        let aux_layout = render_device.create_bind_group_layout(
+            Some("aux_layout"),
+            &[
                 BindGroupLayoutEntry {
                     binding: 0,
                     visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
@@ -79,27 +78,26 @@ impl FromWorld for CuboidsPipelines {
                     count: None,
                 },
             ],
-        });
+        );
 
-        let transforms_layout =
-            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-                label: Some("transforms_layout"),
-                entries: &[BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: ShaderStages::VERTEX,
-                    ty: BindingType::Buffer {
-                        ty: BufferBindingType::Uniform,
-                        has_dynamic_offset: true,
-                        // We always have a single transform for each instance buffer.
-                        min_binding_size: Some(CuboidsTransform::min_size()),
-                    },
-                    count: None,
-                }],
-            });
+        let transforms_layout = render_device.create_bind_group_layout(
+            Some("transforms_layout"),
+            &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::VERTEX,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    // We always have a single transform for each instance buffer.
+                    min_binding_size: Some(CuboidsTransform::min_size()),
+                },
+                count: None,
+            }],
+        );
 
-        let cuboids_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            label: Some("cuboid_instances_layout"),
-            entries: &[BindGroupLayoutEntry {
+        let cuboids_layout = render_device.create_bind_group_layout(
+            Some("cuboid_instances_layout"),
+            &[BindGroupLayoutEntry {
                 binding: 0,
                 visibility: ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
@@ -109,7 +107,7 @@ impl FromWorld for CuboidsPipelines {
                 },
                 count: None,
             }],
-        });
+        );
 
         let sample_count = world.resource::<Msaa>().samples();
         let shader_defs = world.resource::<CuboidsShaderDefs>();

--- a/src/vertex_pulling/plugin.rs
+++ b/src/vertex_pulling/plugin.rs
@@ -71,7 +71,14 @@ impl Plugin for VertexPullingRenderPlugin {
             .init_resource::<TransformsMeta>()
             .init_resource::<UniformBufferOfGpuClippingPlaneRanges>()
             .init_resource::<ViewMeta>()
-            .add_systems(ExtractSchedule, (extract_cuboids, extract_clipping_planes, extract_camera_phases))
+            .add_systems(
+                ExtractSchedule,
+                (
+                    extract_cuboids,
+                    extract_clipping_planes,
+                    extract_camera_phases,
+                ),
+            )
             .add_systems(
                 Render,
                 (

--- a/src/vertex_pulling/queue.rs
+++ b/src/vertex_pulling/queue.rs
@@ -1,9 +1,11 @@
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::DrawCuboids;
+use super::index_buffer::{CuboidsIndexBuffer, CUBE_INDICES_HANDLE};
 use super::pipeline::CuboidsPipelines;
 
 use bevy::core_pipeline::core_3d::Opaque3d;
 use bevy::prelude::*;
+use bevy::render::render_asset::RenderAsset;
 use bevy::render::render_phase::{DrawFunctions, RenderPhase};
 use bevy::render::view::{ExtractedView, VisibleEntities};
 
@@ -33,9 +35,12 @@ pub(crate) fn queue_cuboids(
                         cuboids_pipelines.pipeline_id
                     };
                     opaque_phase.add(Opaque3d {
+                        // TODO: https://github.com/bevyengine/bevy/pull/11671/files
+                        asset_id: AssetId::invalid(),
+                        // asset_id: CUBE_INDICES_HANDLE.into(),
+                        // distance: inverse_view_row_2.dot(entry.position.extend(1.0)),
                         pipeline,
                         entity,
-                        distance: inverse_view_row_2.dot(entry.position.extend(1.0)),
                         draw_function: draw_cuboids,
                         batch_range: 0..1,
                         dynamic_offset: None,

--- a/src/vertex_pulling/queue.rs
+++ b/src/vertex_pulling/queue.rs
@@ -11,7 +11,11 @@ pub(crate) fn queue_cuboids(
     cuboids_pipelines: Res<CuboidsPipelines>,
     opaque_3d_draw_functions: Res<DrawFunctions<AabbOpaque3d>>,
     buffer_cache: Res<CuboidBufferCache>,
-    mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<AabbOpaque3d>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &VisibleEntities,
+        &mut RenderPhase<AabbOpaque3d>,
+    )>,
 ) {
     let draw_cuboids = opaque_3d_draw_functions
         .read()

--- a/src/vertex_pulling/queue.rs
+++ b/src/vertex_pulling/queue.rs
@@ -1,19 +1,17 @@
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::DrawCuboids;
-use super::index_buffer::{CuboidsIndexBuffer, CUBE_INDICES_HANDLE};
+use super::phase::AabbOpaque3d;
 use super::pipeline::CuboidsPipelines;
 
-use bevy::core_pipeline::core_3d::Opaque3d;
 use bevy::prelude::*;
-use bevy::render::render_asset::RenderAsset;
 use bevy::render::render_phase::{DrawFunctions, RenderPhase};
 use bevy::render::view::{ExtractedView, VisibleEntities};
 
 pub(crate) fn queue_cuboids(
     cuboids_pipelines: Res<CuboidsPipelines>,
-    opaque_3d_draw_functions: Res<DrawFunctions<Opaque3d>>,
+    opaque_3d_draw_functions: Res<DrawFunctions<AabbOpaque3d>>,
     buffer_cache: Res<CuboidBufferCache>,
-    mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<Opaque3d>)>,
+    mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<AabbOpaque3d>)>,
 ) {
     let draw_cuboids = opaque_3d_draw_functions
         .read()
@@ -34,11 +32,8 @@ pub(crate) fn queue_cuboids(
                     } else {
                         cuboids_pipelines.pipeline_id
                     };
-                    opaque_phase.add(Opaque3d {
-                        // TODO: https://github.com/bevyengine/bevy/pull/11671/files
-                        asset_id: AssetId::invalid(),
-                        // asset_id: CUBE_INDICES_HANDLE.into(),
-                        // distance: inverse_view_row_2.dot(entry.position.extend(1.0)),
+                    opaque_phase.add(AabbOpaque3d {
+                        distance: inverse_view_row_2.dot(entry.position.extend(1.0)),
                         pipeline,
                         entity,
                         draw_function: draw_cuboids,


### PR DESCRIPTION
I wasn't sure if it was possible to get vertex pulling working with bevy's 0.13's `Opaque3d` pass, so I just re-implements bevy's old (0.12) `Opaque3d` phase as a custom render pass (called `AabbOpaque3d`) that's ordered before bevy's new `Opaque3d` pass. Performance wise I'd expect this to be very slightly slower since it's running 1 additional pass, and there'll be some overdraw over the AABBs if you're mixing regular bevy draws with AABBs (though since the AABB pass is before the `Opaque3d` you'll avoid overdraw where an `Opaque3d` objects is behind an AABB object).

I also fixed the bloom example.

edit: The bloom example may need its values cranked up or exposure change, I haven't compared it to what it looked like previously but bevy's lighting tends to require much higher values in 0.13.